### PR TITLE
Performance improvements

### DIFF
--- a/src/Extensions/OrderExtension.php
+++ b/src/Extensions/OrderExtension.php
@@ -201,7 +201,7 @@ class OrderExtension extends DataExtension
             'SubTotalPrice' => $this->owner->SubTotal()->getDecimalValue(),
             'TotalPrice'    => $this->owner->Total()->getDecimalValue(),
             'PriceCurrency' => $this->owner->Total()->getCurrencyCode(),
-            
+
             'ShippingCostsName'  => '',
             'ShippingCostsValue' => 0.00,
             'ShippingCostsType'  => '',
@@ -313,7 +313,7 @@ class OrderExtension extends DataExtension
         $xmlOrder = $xmlDocument->createElement('orderHeader');
 
         array_walk($data, function (&$value, &$key) use ($xmlOrder, $xmlDocument) {
-            if (is_numeric($value)) {
+            if (is_numeric($value) && $value < 0) {
                 // Ensure negative values are parsed correctly
                 $value = abs($value);
             }

--- a/src/Model/ScheduledWineVariation.php
+++ b/src/Model/ScheduledWineVariation.php
@@ -2,8 +2,8 @@
 
 namespace Isobar\Flow\Model;
 
-use Isobar\Flow\Services\FlowStatus;
 use App\Traits\ReadOnlyDataObject;
+use Isobar\Flow\Services\FlowStatus;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDecimal;
 use SilverStripe\ORM\FieldType\DBHTMLText;
@@ -13,14 +13,15 @@ use SilverStripe\ORM\FieldType\DBVarchar;
  * Class ScheduledWineVariation
  *
  * @package App\Flow\Model
- * @author Lauren Hodgson <lauren.hodgson@littlegiant.co.nz>
+ * @author  Lauren Hodgson <lauren.hodgson@littlegiant.co.nz>
  * @property string $SKU
  * @property string $ForecastGroup
- * @property float $PriceModifierAmount
+ * @property float  $PriceModifierAmount
  * @property string $Status
  * @property string $Title
- * @property int $ScheduledProductID
- * @method \Isobar\Flow\Model\ScheduledWineProduct ScheduledProduct()
+ * @property int    $ScheduledProductID
+ * @property string $VariationType
+ * @method ScheduledWineProduct ScheduledProduct()
  */
 class ScheduledWineVariation extends DataObject
 {
@@ -43,8 +44,7 @@ class ScheduledWineVariation extends DataObject
         'PriceModifierAmount' => DBDecimal::class,
         'Status'              => FlowStatus::ENUM,
         'Title'               => DBVarchar::class,
-        'VariationType'       => DBVarchar::class
-
+        'VariationType'       => DBVarchar::class,
     ];
 
     private static $summary_fields = [

--- a/src/Tasks/Services/ChangeSetPublishTrait.php
+++ b/src/Tasks/Services/ChangeSetPublishTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Isobar\Flow\Tasks\Services;
+
+use App\Ecommerce\Product\WineProduct;
+use BadMethodCallException;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\Versioned\ChangeSet;
+
+trait ChangeSetPublishTrait
+{
+    /**
+     * @var ChangeSet
+     */
+    protected $changeSet = null;
+
+    /**
+     * Publish / update a record
+     *
+     * @param DataObject $record
+     * @throws ValidationException
+     */
+    protected function publish(DataObject $record)
+    {
+        if (empty($this->changeSet)) {
+            throw new BadMethodCallException("runProcessData not called");
+        }
+        if ($record->isChanged(null, DataObject::CHANGE_VALUE)) {
+            $record->write();
+        }
+
+        // If item is an unpublished wine product, do not publish it
+        // This requires records to be manually published
+        if ($record instanceof WineProduct && !$record->isPublished()) {
+            return;
+        }
+
+        // Ensure changeset is saved when adding the first item
+        if (!$this->changeSet->isInDB()) {
+            $this->changeSet->write();
+        }
+        $this->changeSet->addObject($record);
+    }
+
+    protected function initChangeSet()
+    {
+        $this->changeSet = ChangeSet::create();
+    }
+
+    protected function finishChangeSet()
+    {
+        // If we have saved at least one record, publish changeset
+        if ($this->changeSet->isInDB()) {
+            $this->changeSet->publish();
+        }
+        $this->changeSet = null;
+    }
+}

--- a/src/Tasks/Services/PricingImport.php
+++ b/src/Tasks/Services/PricingImport.php
@@ -165,13 +165,8 @@ class PricingImport
                 $scheduledVariation->setField('PriceModifierAmount', 0);
             } else {
                 // Calculate the difference
-                $diff = floatval($pricing['currentSellingPriceUnit']) - $productBasePrice;
-
-                // Calculate the price modifier - must be saved without decimal place
-                // @todo fix + unit test
-                $moneyFormattedPrice = str_replace('.', '', $diff);
-
-                $scheduledVariation->setField('PriceModifierAmount', $moneyFormattedPrice);
+                $modifier = floatval($pricing['currentSellingPriceUnit']) - $productBasePrice;
+                $scheduledVariation->setField('PriceModifierAmount', $modifier);
             }
 
             $scheduledVariation->write();

--- a/src/Tasks/Services/PricingImport.php
+++ b/src/Tasks/Services/PricingImport.php
@@ -168,6 +168,7 @@ class PricingImport
                 $diff = floatval($pricing['currentSellingPriceUnit']) - $productBasePrice;
 
                 // Calculate the price modifier - must be saved without decimal place
+                // @todo fix + unit test
                 $moneyFormattedPrice = str_replace('.', '', $diff);
 
                 $scheduledVariation->setField('PriceModifierAmount', $moneyFormattedPrice);

--- a/src/Tasks/Services/ProcessProducts.php
+++ b/src/Tasks/Services/ProcessProducts.php
@@ -201,6 +201,7 @@ class ProcessProducts
 
         // Process the price
         if ($scheduledProduct->BasePrice > 0) {
+            // @todo fix + unit test
             $moneyFormattedPrice = str_replace('.', '', $scheduledProduct->BasePrice);
 
             $wineProduct->setField('BasePriceAmount', $moneyFormattedPrice);
@@ -209,6 +210,7 @@ class ProcessProducts
 
         // Process the pack price
         if ($scheduledProduct->PackPrice > 0) {
+            // @todo fix + unit test
             $moneyFormattedPrice = str_replace('.', '', $scheduledProduct->PackPrice);
 
             $wineProduct->setField('PackPriceAmount', $moneyFormattedPrice);
@@ -216,6 +218,7 @@ class ProcessProducts
         }
 
         // Enough info to write
+        // @todo only run if isChanged()
         $wineProduct->write();
 
         // If the wine product has been published in the past, it should be safe to re-publish
@@ -300,6 +303,8 @@ class ProcessProducts
                 'ProductID' => $wineProductID
             ]);
 
+            // @todo if isChanged && isPublished()
+
             $vintageAttributeID = $vintageAttribute->write();
             $vintageAttribute->publishRecursive();
         }
@@ -315,6 +320,7 @@ class ProcessProducts
         $modifier = $scheduledWineVariation->PriceModifierAmount;
 
         if ($modifier > 0) {
+            // @todo fix
             $modifier = str_replace('.', '', $modifier);
         }
 
@@ -323,6 +329,7 @@ class ProcessProducts
             $productAttributeOption->setField('SKU', $scheduledWineVariation->SKU);
             $productAttributeOption->setField('PriceModifierAmount', $modifier);
 
+            // @todo move out of the loop, put inside the if() statement along with publish()
             $productAttributeOption->write();
 
             $productAttributeOptionID = $productAttributeOption->ID;
@@ -338,9 +345,11 @@ class ProcessProducts
                 'PriceModifierCurrency' => 'NZD' // TODO: Use dynamic currency
             ]);
 
+            // @todo same as above
             $productAttributeOptionID = $productAttributeOption->write();
         }
 
+        // @todo only publish if changed
         $productAttributeOption->publishSingle();
 
         // Get the options
@@ -357,6 +366,8 @@ class ProcessProducts
             /** @noinspection PhpUndefinedFieldInspection */
             if (!$wineProductVariation->SKU) {
                 $wineProductVariation->setField('SKU', $scheduledWineVariation->SKU);
+
+                // @todo only write / publish if changed
                 $wineProductVariation->write();
                 $wineProductVariation->publishSingle();
             }
@@ -419,6 +430,10 @@ class ProcessProducts
     /**
      * @return bool
      * Deletes all the products that don't exist in the imported data table (ScheduledProduct)
+     *
+     * @todo - Check if this method is
+     *        - 1 safe to keep / fix
+     *        - 2 needed
      */
     private function deleteOldProducts()
     {
@@ -444,6 +459,7 @@ class ProcessProducts
 
         /** @var WineProduct $product */
         foreach ($productsToPublish as $product) {
+            // @todo maybe comment this out for now, until we figure out if it's necessary
             if ($product->isPublished()) {
                 $product->publishRecursive();
             }

--- a/src/Tasks/Services/ProcessProducts.php
+++ b/src/Tasks/Services/ProcessProducts.php
@@ -59,6 +59,10 @@ class ProcessProducts
         if ($record->isChanged(null, DataObject::CHANGE_VALUE)) {
             $record->write();
         }
+        // Ensure changeset is saved when adding the first item
+        if (!$this->changeSet->isInDB()) {
+            $this->changeSet->write();
+        }
         $this->changeSet->addObject($record);
     }
 
@@ -79,7 +83,10 @@ class ProcessProducts
         } catch (ValidationException $e) {
             throw new FlowException($e->getMessage(), $e->getCode());
         } finally {
-            $this->changeSet->publish();
+            // If we have saved at least one record, publish changeset
+            if ($this->changeSet->isInDB()) {
+                $this->changeSet->publish();
+            }
             $this->changeSet = null;
         }
 

--- a/src/Tasks/Services/ProcessProducts.php
+++ b/src/Tasks/Services/ProcessProducts.php
@@ -214,14 +214,11 @@ class ProcessProducts
         }
 
         // Enough info to write
-        // @todo only run if isChanged()
         if ($wineProduct->isChanged()) {
             $wineProduct->write();
-        }
-
-        // If the wine product has been published in the past, it should be safe to re-publish
-        if ($wineProduct->isPublished()) {
-            $wineProduct->publishRecursive();
+            if ($wineProduct->isPublished()) {
+                $wineProduct->publishRecursive();
+            }
         }
 
 

--- a/src/Tasks/Services/ProcessProducts.php
+++ b/src/Tasks/Services/ProcessProducts.php
@@ -56,7 +56,7 @@ class ProcessProducts
         if (empty($this->changeSet)) {
             throw new BadMethodCallException("runProcessData not called");
         }
-        if ($record->isChanged()) {
+        if ($record->isChanged(null, DataObject::CHANGE_VALUE)) {
             $record->write();
         }
         $this->changeSet->addObject($record);

--- a/src/Tasks/Services/ProductImport.php
+++ b/src/Tasks/Services/ProductImport.php
@@ -148,31 +148,24 @@ class ProductImport
             $scheduledProduct->write();
         }
 
+        $updateScheduledWineVariation = [
+            'Title'         => $product['packingSize'],
+            'SKU'           => $product['productCode'],
+            'ForecastGroup' => $product['forecastGroup'],
+            'VariationType' => 'Pack'
+        ];
+
         // Check to see if this is a non-vintage option
         if ($product['vintage'] != 'NVIN') {
-
-            // Import variations
-            $scheduledVariation = ScheduledWineVariation::create([
-                'Title'         => $product['vintage'],
-                'SKU'           => $product['productCode'],
-                'ForecastGroup' => $product['forecastGroup'],
-                'VariationType' => 'Vintage'
-
-            ]);
-        } else {
-            // Use the packing size instead
-            $scheduledVariation = ScheduledWineVariation::create([
-                'Title'         => $product['packingSize'],
-                'SKU'           => $product['productCode'],
-                'ForecastGroup' => $product['forecastGroup'],
-                'VariationType' => 'Pack'
-            ]);
+            $updateScheduledWineVariation['Title'] = $product['vintage'];
+            $updateScheduledWineVariation['VariationType'] = 'Vintage';
         }
 
+        $scheduledVariation = ScheduledWineVariation::create();
+        $scheduledVariation->update($updateScheduledWineVariation);
         $scheduledVariation->write();
 
         $scheduledProduct->ScheduledVariations()->add($scheduledVariation);
-
         $scheduledProduct->write();
     }
 }

--- a/src/Tasks/Services/ProductImport.php
+++ b/src/Tasks/Services/ProductImport.php
@@ -138,7 +138,8 @@ class ProductImport
         if (!$scheduledProduct) {
             $title = preg_replace('!\s+!', ' ', $product['productDescription']);
 
-            $scheduledProduct = ScheduledWineProduct::create([
+            $scheduledProduct = ScheduledWineProduct::create();
+            $scheduledProduct->update([
                 'ForecastGroup' => $product['forecastGroup'],
                 'PackSize'      => $product['packingSize'],
                 'Description'   => $title

--- a/src/Tasks/Services/StockImport.php
+++ b/src/Tasks/Services/StockImport.php
@@ -119,20 +119,29 @@ class StockImport
                     $productVariation->setField('OutOfStock', 0);
                 }
 
-                $productVariation->write();
-                $productVariation->publishSingle();
-
-                $wineProduct = $productVariation->Product();
-
-                if ($wineProduct && $wineProduct->exists()) {
-                    // Publish the product too
-                    $wineProduct->write();
-
-                    // If the wine product has been published in the past, it should be safe to re-publish
-                    if ($wineProduct->isPublished()) {
-                        $wineProduct->publishSingle();
+                if ($productVariation->isChanged()) {
+                    $productVariation->write();
+                    if ($productVariation->isPublished()) {
+                        $productVariation->publishSingle();
                     }
                 }
+
+                // @todo check this is safe to remove
+
+//                $productVariation->write();
+//                $productVariation->publishSingle();
+//
+//                $wineProduct = $productVariation->Product();
+//
+//                if ($wineProduct && $wineProduct->exists()) {
+//                    // Publish the product too
+//                    $wineProduct->write();
+//
+//                    // If the wine product has been published in the past, it should be safe to re-publish
+//                    if ($wineProduct->isPublished()) {
+//                        $wineProduct->publishSingle();
+//                    }
+//                }
             }
         }
     }

--- a/src/Tasks/Services/StockImport.php
+++ b/src/Tasks/Services/StockImport.php
@@ -42,6 +42,10 @@ class StockImport
         if ($record->isChanged(null, DataObject::CHANGE_VALUE)) {
             $record->write();
         }
+        // Ensure changeset is saved when adding the first item
+        if (!$this->changeSet->isInDB()) {
+            $this->changeSet->write();
+        }
         $this->changeSet->addObject($record);
     }
 
@@ -64,7 +68,10 @@ class StockImport
         } catch (Exception $e) {
             throw new FlowException($e->getMessage(), $e->getCode());
         } finally {
-            $this->changeSet->publish();
+            // If we have saved at least one record, publish changeset
+            if ($this->changeSet->isInDB()) {
+                $this->changeSet->publish();
+            }
             $this->changeSet = null;
         }
 

--- a/src/Tasks/Services/StockImport.php
+++ b/src/Tasks/Services/StockImport.php
@@ -125,23 +125,6 @@ class StockImport
                         $productVariation->publishSingle();
                     }
                 }
-
-                // @todo check this is safe to remove
-
-//                $productVariation->write();
-//                $productVariation->publishSingle();
-//
-//                $wineProduct = $productVariation->Product();
-//
-//                if ($wineProduct && $wineProduct->exists()) {
-//                    // Publish the product too
-//                    $wineProduct->write();
-//
-//                    // If the wine product has been published in the past, it should be safe to re-publish
-//                    if ($wineProduct->isPublished()) {
-//                        $wineProduct->publishSingle();
-//                    }
-//                }
             }
         }
     }

--- a/src/Tasks/Services/StockImport.php
+++ b/src/Tasks/Services/StockImport.php
@@ -37,7 +37,7 @@ class StockImport
     protected function publish(DataObject $record)
     {
         if (empty($this->changeSet)) {
-            throw new BadMethodCallException("runProcessData not called");
+            throw new BadMethodCallException("runImport not called");
         }
         if ($record->isChanged(null, DataObject::CHANGE_VALUE)) {
             $record->write();


### PR DESCRIPTION
There was an issue where changes such as 10 -> "10" were being detected as "strict" changes and triggering a DB version increment.

I also made sure that if an import makes multiple publishes to a product in one import, it does this in a single changeset. This will reduce the number of DB modifications.

I cleaned up a bunch of code that was bad, wrong, or ugly.